### PR TITLE
Add an option to initialize private connections

### DIFF
--- a/awesome/dbus.lua
+++ b/awesome/dbus.lua
@@ -8,11 +8,14 @@ local dbus = {}
 
 -- dbus loop
 
-function dbus.init()
+function dbus.init(need_private_connections)
     dbus.signals = {}
     dbus.callbacks = {}
-    dbus.session = ldbus.bus.get('session')
-    dbus.system  = ldbus.bus.get('system')
+    local getter = need_private_connections
+      and ldbus.bus.get_private
+      or ldbus.bus.get
+    dbus.session = getter('session')
+    dbus.system  = getter('system')
 end
 
 function dbus.exit()


### PR DESCRIPTION
**Problem**: bus connections don’t close after Lua object that represents the connection is destroyed.
**Solution**: add an option to initialize private bus connections. A private connection is destroyed along with the Lua object that represents it.

Necessary for cases that require breaking connections.